### PR TITLE
Revert "devicetree: Don't specify vbus gpio in factory dts"

### DIFF
--- a/arch/arm/boot/dts/zero-gravitas-factory.dts
+++ b/arch/arm/boot/dts/zero-gravitas-factory.dts
@@ -42,7 +42,7 @@
 			regulator-name = "usb_otg1_vbus";
 			regulator-min-microvolt = <5000000>;
 			regulator-max-microvolt = <5000000>;
-			/*gpio = <&gpio4 15 0>;*/
+			gpio = <&gpio4 15 0>;
 			enable-active-high;
 			vin-supply = <&swbst_reg>;
 		};

--- a/arch/arm/boot/dts/zero-gravitas.dts
+++ b/arch/arm/boot/dts/zero-gravitas.dts
@@ -1,10 +1,6 @@
 #include "zero-gravitas-factory.dts"
 
-&reg_usb_otg1_vbus {
-	gpio = <&gpio4 15 0>;
-};
-
 &usbotg1 {
-	vbus-supply = <&reg_usb_otg1_vbus>;
+        vbus-supply = <&reg_usb_otg1_vbus>;
 };
 


### PR DESCRIPTION
This reverts commit 5c76066147837274124f25afdce5432eb0efa269.